### PR TITLE
Added automatic generation of things directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *~
 \#*\#
-
+things
 .repl-*
 .nrepl-*
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ downward.
 * [Install OpenSCAD](http://www.openscad.org/)
 
 **Generating the design**
+* cd into the root of the project.
 * Run `lein repl`
 * Load the file `(load-file "src/dactyl_pivot/dactyl.clj")`
-* This will regenerate the `things/*.scad` files
+* This will generate or regenerate the `things/*.scad` files
 * Use OpenSCAD to open a `.scad` file.
 * Make changes to design, repeat `load-file`, OpenSCAD will watch for changes and rerender.
 * When done, use OpenSCAD to export STL files

--- a/src/dactyl_pivot/dactyl.clj
+++ b/src/dactyl_pivot/dactyl.clj
@@ -3,7 +3,8 @@
     (:require [clojure.core.matrix :refer [array matrix mmul]]
               [scad-clj.scad :refer :all]
               [scad-clj.model :refer :all]
-              [unicode-math.core :refer :all]))
+              [unicode-math.core :refer :all]
+              [clojure.java.io :as io]))
 
 
 (defn deg2rad [degrees]
@@ -978,7 +979,7 @@
     )
 )
 
-
+(.mkdir (java.io.File. "things"))
 (spit "things/assembled-right.scad"
       (write-scad dactyl-top-right))
 


### PR DESCRIPTION
The `things` directory is now automatically generated if it didn't exist before.

Previous to this PR, loading `dactyl.clj` after a fresh clone resulted in an error since the `things` directory doesn't exist.