### PR TITLE
Adjust the location of the M3 hole when extra-row

### DIFF
--- a/src/dactyl_pivot/dactyl-open.clj
+++ b/src/dactyl_pivot/dactyl-open.clj
@@ -598,7 +598,7 @@
         (key-place 0 0 (mount-hole :up))
         (key-place (+  innercol-offset 1) lastrow (mount-hole :down))
         (key-place lastcol 0 (mount-hole :up))
-        (key-place lastcol cornerrow ( mount-hole :down))
+        (key-place lastcol (if extra-row lastrow cornerrow) ( mount-hole :down))
     )
 )
 (def thumb-plate-holes

--- a/src/dactyl_pivot/dactyl-open.clj
+++ b/src/dactyl_pivot/dactyl-open.clj
@@ -721,9 +721,9 @@
       (hull
             (->> (sphere out-radius)
                 (translate floor-anchor-poslr))
-            (key-place lastcol cornerrow (support-face :down (- -1.5 plate-thickness)))
+            (key-place lastcol (if extra-row lastrow cornerrow) (support-face :down (- -1.5 plate-thickness)))
       )
-      (key-place lastcol cornerrow (support-m :down (- -0.1 plate-thickness)))
+      (key-place lastcol (if extra-row lastrow cornerrow) (support-m :down (- -0.1 plate-thickness)))
 
       ; upper right pole
       (hull
@@ -798,14 +798,14 @@
                   (with-fn 30))]
         (union
           ; screw holes below mounting holes
-          (key-place lastcol cornerrow (ext-out :down (- -0.1 plate-thickness)  (with-fn 30 (cylinder inner-radius 10))))
+          (key-place lastcol (if extra-row lastrow cornerrow) (ext-out :down (- -0.1 plate-thickness)  (with-fn 30 (cylinder inner-radius 10))))
           (key-place lastcol 0 (ext-out :up (- -0.1 plate-thickness) (with-fn 30 (cylinder inner-radius 10))))
           (key-place 0 0 (ext-out :up (- -0.1 plate-thickness) (with-fn 30 (cylinder inner-radius 10))))
           (key-place (+  innercol-offset 1) lastrow (ext-out :down (- -0.1 plate-thickness) (with-fn 30 (cylinder inner-radius 10))))
 
           ; m3 hex nuts
           (key-place lastcol 0 (hex-slot :up (- -4 plate-thickness)))
-          (key-place lastcol cornerrow (hex-slot :down (- -4 plate-thickness)))
+          (key-place lastcol (if extra-row lastrow cornerrow) (hex-slot :down (- -4 plate-thickness)))
           (key-place 0 0 (hex-slot :up (- -4 plate-thickness)))
           (key-place (+  innercol-offset 1) lastrow (hex-slot :down (- -4 plate-thickness)))
           (->> (m3hex 0.3)


### PR DESCRIPTION
The location of the M3 screw hole on the bottom pinky side should be adjusted when `extra-row` is true.

Please take a look at the captured images below:
Before the patch:
![image](https://github.com/chenfucn/dactyl-pivot/assets/1924548/2a6a7a85-0365-4ae7-a852-48a9c9ba8b39)
After the patch:
![image](https://github.com/chenfucn/dactyl-pivot/assets/1924548/96dfdcb4-ba26-4f69-8106-fc54df796132)

I do not know Clojure, so please utilize the code with a grain of salt.

Thank you.